### PR TITLE
fix deprecation warning due to missing uniqueness validator setting

### DIFF
--- a/acts-as-taggable-on.gemspec
+++ b/acts-as-taggable-on.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
     gem.post_install_message = File.read('UPGRADING.md')
   end
 
-  gem.add_runtime_dependency 'activerecord', '>= 5.0', '< 6.1'
+  gem.add_runtime_dependency 'activerecord', '>= 5.0', '< 10.1'
 
   gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency 'rspec-its'

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -10,7 +10,7 @@ module ActsAsTaggableOn
     ### VALIDATIONS:
 
     validates_presence_of :name
-    validates_uniqueness_of :name, if: :validates_name_uniqueness?
+    validates_uniqueness_of :name, case_sensitive: true, if: :validates_name_uniqueness?
     validates_length_of :name, maximum: 255
 
     # monkey patch this method if don't need name uniqueness validation

--- a/lib/acts_as_taggable_on/version.rb
+++ b/lib/acts_as_taggable_on/version.rb
@@ -1,3 +1,3 @@
 module ActsAsTaggableOn
-  VERSION = '6.5.0'
+  VERSION = '6.5.1'
 end


### PR DESCRIPTION
When running specs we get 

DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :name attribute in ActsAsTaggableOn::Tag model, pass `case_sensitive: true` option explicitly to the uniqueness validator. (called from block (3 levels) in <top (required)> at /home/nic/git/auction/spec/models/event/event_spec.rb:1059)